### PR TITLE
Add qol changes

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -69,7 +69,7 @@ export const update = async (shouldCommit = false) => {
           .map((i) => i.trim())
           .filter((i) => i.length);
 
-      if (dayjs(metadata.end).isBefore(dayjs())) {
+      if ((metadata.end !== "unknown") && dayjs(metadata.end).isBefore(dayjs())) {
         await octokit.issues.unlock({
           owner,
           repo,
@@ -345,22 +345,55 @@ generator: Upptime <https://github.com/upptime/upptime>
 
           // If the site was just recorded as down or degraded, open an issue
           if ((status === "down" || status === "degraded") && !expected) {
+            const issueTitle = (config.issueTitle || "$PREFIX $SITE_NAME is $STATUS")
+              .replace(
+                "$PREFIX",
+                status === "down"
+                  ? config.issuePrefixStatusDown || "🛑"
+                  : config.issuePrefixStatusDegraded || "⚠️"
+              )
+              .replace("$SITE_NAME", site.name)
+              .replace("$SITE_URL", site.url)
+              .replace("$SITE_METHOD", site.method || "GET")
+              .replace(
+                "$STATUS",
+                status === "down"
+                  ? status
+                  : "experiencing degraded performance"
+              )
+              .replace("$RESPONSE_CODE", result.httpCode.toString())
+              .replace("$RESPONSE_TIME", responseTime)
+              .replace("$COMMIT", lastCommitSha.substr(0, 7))
+              .replace("$COMMIT_URL", `https://github.com/${owner}/${repo}/commit/${lastCommitSha}`);
+            const issueBody = (config.issueBody || `[[\`$COMMIT\`]($COMMIT_URL)] $SITE_NAME ($SITE_URL) is **$STATUS**.
+- HTTP code: $RESPONSE_CODE
+- Response time: $RESPONSE_TIME ms
+`)
+              .replace(
+                "$PREFIX",
+                status === "down"
+                  ? config.issuePrefixStatusDown || "🛑"
+                  : config.issuePrefixStatusDegraded || "⚠️"
+              )
+              .replace("$SITE_NAME", site.name)
+              .replace("$SITE_URL", site.url)
+              .replace("$SITE_METHOD", site.method || "GET")
+              .replace(
+                "$STATUS",
+                status === "down"
+                  ? status
+                  : "experiencing degraded performance"
+              )
+              .replace("$RESPONSE_CODE", result.httpCode.toString())
+              .replace("$RESPONSE_TIME", responseTime)
+              .replace("$COMMIT", lastCommitSha.substr(0, 7))
+              .replace("$COMMIT_URL", `https://github.com/${owner}/${repo}/commit/${lastCommitSha}`);
             if (!issues.data.length) {
               const newIssue = await octokit.issues.create({
                 owner,
                 repo,
-                title:
-                  status === "down"
-                    ? `🛑 ${site.name} is down`
-                    : `⚠️ ${site.name} has degraded performance`,
-                body: `In [\`${lastCommitSha.substr(
-                  0,
-                  7
-                )}\`](https://github.com/${owner}/${repo}/commit/${lastCommitSha}), ${site.name} (${site.url
-                  }) ${status === "down" ? "was **down**" : "experienced **degraded performance**"}:
-- HTTP code: ${result.httpCode}
-- Response time: ${responseTime} ms
-`,
+                title: issueTitle,
+                body: issueBody,
                 labels: ["status", slug, ...site.tags || []],
               });
               const assignees = [...(config.assignees || []), ...(site.assignees || [])];


### PR DESCRIPTION
First of all would I like to mention that I have no idea if I made this right or not... Typescript is not my strong side (I have like 0 experience) and I made this within the GitHub editor...

With that out of the way, this PR addresses some of the suggestions I made in the past, namely https://github.com/upptime/upptime/discussions/569 and https://github.com/upptime/upptime/discussions/572, by not only changing the default status message to be no longer in the past tense ("was" isn't really accurate when the issue has just been created because of the site being down) but also adding new config options `issueTitle` and `issueBody` for people to be able to change the respective text to what they prefer.

It also adds new options `issuePrefixStatusDown` and `issuePrefixStatusDegraded` to replace `$PREFIX` in issue title and body with an emoji/text based on the status (Down or degraded)

Finally does it also add a simple check `metadata.end !== "unknown"` to when checking if a maintenance issue is past its end-date to be closed.
This should help setting a maintenance task with not yet known end date (Useful for maintenance that f.e. relies on outside/3rd party sources/hosts). This may also require changes to the status page to work...

I really hope this looks fine. If not, feedback and especially corrections are very welcome here!